### PR TITLE
Update to latest LetsEncrypt formula

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ install:
     gem 'test-kitchen'
     gem 'kitchen-docker'
     gem 'kitchen-inspec'
-    gem 'inspec'
+    gem 'inspec', '<3.0.0'
+    #Version was frozen, because of issues in the version of inspec >3.0.0 -- see https://mirantis.jira.com/browse/PROD-24324 for more info
     gem 'kitchen-salt', :git => 'https://github.com/salt-formulas/kitchen-salt.git'
   - bundle install
 

--- a/letsencrypt/client/domain.sls
+++ b/letsencrypt/client/domain.sls
@@ -7,7 +7,7 @@
 {%-   set staging = '' %}
 {%- endif %}
 
-{%- for domain, params in client.get('domain', {}).iteritems() %}
+{%- for domain, params in client.get('domain', {}).items() %}
 {%- if params.get('enabled', true) %}
 {%- set auth = params.auth|default(client.auth) %}
 {%- set main_domain = params.name|default(domain) %}

--- a/letsencrypt/client/domain.sls
+++ b/letsencrypt/client/domain.sls
@@ -25,7 +25,7 @@ certbot_{{ domain }}:
     - name: >
         certbot certonly {{ staging }} --non-interactive --agree-tos --no-self-upgrade --email {{ params.email|default(client.email) }}
         {%- if auth.method == 'standalone' %}
-        --standalone --standalone-supported-challenges {{ auth.type }} --http-01-port {{ auth.port }}
+        --standalone --preferred-challenges {{ auth.type }} --http-01-port {{ auth.port }}
         {%- elif auth.method == 'webroot' %}
         --webroot --webroot-path {{ auth.path }}
         {%- elif auth.method in ['apache', 'nginx'] %}

--- a/letsencrypt/client/init.sls
+++ b/letsencrypt/client/init.sls
@@ -18,7 +18,7 @@ certbot_packages_openssl:
 
 certbot_packages:
   pkg.installed:
-    - names: {{ (client.source.pkgs + extra_packages) | tojson }}
+    - names: {{ (client.source.pkgs + extra_packages) | json }}
     - watch_in:
       - cmd: certbot_installed
 

--- a/letsencrypt/client/init.sls
+++ b/letsencrypt/client/init.sls
@@ -18,7 +18,7 @@ certbot_packages_openssl:
 
 certbot_packages:
   pkg.installed:
-    - names: {{ client.source.pkgs + extra_packages }}
+    - names: {{ (client.source.pkgs + extra_packages) | tojson }}
     - watch_in:
       - cmd: certbot_installed
 


### PR DESCRIPTION
This should fix a bug with Salt trying to install unicode literals as packages (https://github.com/saltstack/salt/issues/51925).